### PR TITLE
Add used dependencies explicitly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>27.0.1</version>
+		<version>28.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -91,9 +91,10 @@
 		<!-- LICENSE -->
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>Deborah Schmidt</license.copyrightOwners>
+
 		<tensorflow.version>1.13.1</tensorflow.version>
 		<imagej-tensorflow.version>1.1.4</imagej-tensorflow.version>
-
+		<csbdeep.version>0.5.0</csbdeep.version>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
@@ -112,19 +113,64 @@
 			<artifactId>imagej</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-common</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-ops</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-tensorflow</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-common</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>io.scif</groupId>
+			<artifactId>scifio</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>de.csbdresden</groupId>
 			<artifactId>csbdeep</artifactId>
-			<version>0.5.0</version>
+			<version>${csbdeep.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.tensorflow</groupId>
+			<artifactId>libtensorflow</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
-			<version>1.21</version>
 		</dependency>
+
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>1.3.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-math3</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
 		</dependency>
 		
 		<!-- Graphing dependency -->


### PR DESCRIPTION
This commit fixes the following warnings reported by `mvn dependency:analyze`:

```
[WARNING] Used undeclared dependencies found:
[WARNING]    org.apache.commons:commons-math3:jar:3.6.1:compile
[WARNING]    org.apache.commons:commons-lang3:jar:3.8.1:compile
[WARNING]    io.scif:scifio:jar:0.37.3:compile
[WARNING]    org.tensorflow:libtensorflow:jar:1.13.1:compile
[WARNING]    org.apache.commons:commons-compress:jar:1.18:compile
[WARNING]    net.imagej:imagej-common:jar:0.28.2:compile
[WARNING]    net.imagej:imagej-ops:jar:0.43.2:compile
[WARNING]    org.scijava:scijava-common:jar:2.77.0:compile
[WARNING]    net.imglib2:imglib2:jar:5.6.3:compile
[WARNING]    net.imagej:imagej-tensorflow:jar:1.1.4:compile
```

In addition, it bumps the parent version to pom-scijava `28.0.0`, it removes hard-coded version definitions in favor of those managed by pom-scijava, and it defines a version property for `csbdeep`.